### PR TITLE
2 fetchdecodeexecute loop and base cpu flow

### DIFF
--- a/src/architecture/cond_flags.rs
+++ b/src/architecture/cond_flags.rs
@@ -1,6 +1,14 @@
+/// LC-3 condition flags stored in the COND register.
+#[repr(u16)]
 #[derive(Debug, Clone, Copy)]
 pub enum CondFlag {
     Pos = 1 << 0, // P
     Zro = 1 << 1, // Z
     Neg = 1 << 2, // N
+}
+
+impl From<CondFlag> for u16 {
+    fn from(flag: CondFlag) -> Self {
+        flag as u16
+    }
 }

--- a/src/architecture/mod.rs
+++ b/src/architecture/mod.rs
@@ -5,3 +5,5 @@ mod vm;
 pub use cond_flags::CondFlag;
 pub use registers::Register;
 pub use vm::VM;
+/// Default LC-3 program counter start address.
+pub const START_PC: u16 = 0x3000;

--- a/src/architecture/registers.rs
+++ b/src/architecture/registers.rs
@@ -1,3 +1,7 @@
+const START_PC: u16 = 0x3000;
+
+/// LC-3 register indices.
+#[repr(usize)]
 #[derive(Copy, Clone, Debug)]
 pub enum Register {
     R0 = 0,
@@ -11,6 +15,12 @@ pub enum Register {
     PC,   // Program Counter
     Cond, // Condition Flags
     Count,
+}
+
+impl From<Register> for usize {
+    fn from(reg: Register) -> Self {
+        reg as usize
+    }
 }
 
 #[cfg(test)]

--- a/src/architecture/vm.rs
+++ b/src/architecture/vm.rs
@@ -49,4 +49,9 @@ impl VM {
     pub fn read_mem(&self, address: u16) -> u16 {
         self.memory[address as usize]
     }
+
+    /// Write a 16-bit value to memory.
+    pub fn write_mem(&mut self, address: u16, value: u16) {
+        self.memory[address as usize] = value;
+    }
 }

--- a/src/architecture/vm.rs
+++ b/src/architecture/vm.rs
@@ -1,26 +1,52 @@
 use crate::architecture::Register;
 
 const MEMORY_SIZE: usize = 1 << 16;
+
+/// LC-3 virtual machine state (registers, memory, and run flag).
 pub struct VM {
-    pub reg: [u16; Register::Count as usize], // Registers including PC and COND
-    pub memory: [u16; MEMORY_SIZE],           // Memory
+    reg: [u16; Register::Count as usize], // Registers including PC and COND
+    memory: [u16; MEMORY_SIZE],           // Memory
+    running: bool,
 }
 
 impl VM {
+    /// Create a new VM with zeroed memory and registers.
+    ///
+    /// The program counter starts at the LC-3 default of `0x3000` and the VM
+    /// is marked as running.
     pub fn new() -> Self {
-        VM {
-            reg: [0; Register::Count as usize],
+        let mut reg = [0; Register::Count as usize];
+        reg[Register::PC as usize] = 0x3000; // Initialize PC
+
+        Self {
+            reg,
             memory: [0; MEMORY_SIZE],
+            running: true,
         }
     }
 
-    #[inline]
-    pub fn reg(&self, r: Register) -> u16 {
-        self.reg[r as usize]
+    /// Returns whether the VM is still running.
+    pub fn is_running(&self) -> bool {
+        self.running
     }
 
-    #[inline]
-    pub fn set_reg(&mut self, r: Register, val: u16) {
-        self.reg[r as usize] = val;
+    /// Stop the VM execution loop.
+    pub fn shut_down(&mut self) {
+        self.running = false;
+    }
+
+    /// Read the value of a register by index.
+    pub fn reg(&self, r: usize) -> u16 {
+        self.reg[r]
+    }
+
+    /// Write a value to a register by index.
+    pub fn set_reg(&mut self, r: usize, val: u16) {
+        self.reg[r] = val;
+    }
+
+    /// Read a 16-bit value from memory.
+    pub fn read_mem(&self, address: u16) -> u16 {
+        self.memory[address as usize]
     }
 }

--- a/src/helper_funcs/read_u16_be.rs
+++ b/src/helper_funcs/read_u16_be.rs
@@ -1,5 +1,6 @@
 use std::io::Read;
 
+/// Read a big-endian `u16` from the provided reader.
 pub fn read_u16_be<R: Read>(r: &mut R) -> std::io::Result<u16> {
     let mut buf = [0u8; 2];
     r.read_exact(&mut buf)?;

--- a/src/helper_funcs/update_flags.rs
+++ b/src/helper_funcs/update_flags.rs
@@ -16,17 +16,17 @@ use crate::architecture::{CondFlag, Register, VM};
 /// };
 ///
 /// update_flags(0, &mut vm);
-/// assert_eq!(vm.reg(Register::Cond), CondFlag::Zro as u16);
+/// assert_eq!(vm.reg(Register::Cond), CondFlag::Zro);
 /// ```
 pub fn update_flags(r: u16, vm: &mut VM) {
     if r == 0 {
-        vm.set_reg(Register::Cond, CondFlag::Zro as u16);
+        vm.set_reg(Register::Cond.into(), CondFlag::Zro.into());
     } else if r >> 15 == 1 {
         // Is negative
-        vm.set_reg(Register::Cond, CondFlag::Neg as u16);
+        vm.set_reg(Register::Cond.into(), CondFlag::Neg.into());
     } else {
         // Is positive
-        vm.set_reg(Register::Cond, CondFlag::Pos as u16);
+        vm.set_reg(Register::Cond.into(), CondFlag::Pos.into());
     }
 }
 
@@ -41,7 +41,7 @@ mod tests {
 
         update_flags(0, &mut vm);
 
-        assert_eq!(vm.reg(Register::Cond), CondFlag::Zro as u16);
+        assert_eq!(vm.reg(Register::Cond.into()), CondFlag::Zro.into());
     }
 
     #[test]
@@ -51,7 +51,7 @@ mod tests {
 
         update_flags(0x8000, &mut vm);
 
-        assert_eq!(vm.reg(Register::Cond), CondFlag::Neg as u16);
+        assert_eq!(vm.reg(Register::Cond.into()), CondFlag::Neg.into());
     }
 
     #[test]
@@ -61,6 +61,6 @@ mod tests {
 
         update_flags(0x0001, &mut vm);
 
-        assert_eq!(vm.reg(Register::Cond), CondFlag::Pos as u16);
+        assert_eq!(vm.reg(Register::Cond.into()), CondFlag::Pos.into());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,17 @@
 mod architecture;
 mod helper_funcs;
-mod op_codes;
+mod op;
+mod step;
+mod run;
+
+use crate::architecture::{Register, CondFlag, VM, START_PC};
+use crate::run::run;
 
 fn main() {
-    println!("Hello, world!");
+    let mut vm = VM::new();
+
+    vm.set_reg(Register::Cond.into(), CondFlag::Pos.into());
+    vm.set_reg(Register::PC.into(), START_PC);
+
+    run(&mut vm);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
 mod architecture;
 mod helper_funcs;
 mod op;
-mod step;
 mod run;
+mod step;
 
-use crate::architecture::{Register, CondFlag, VM, START_PC};
+use crate::architecture::{CondFlag, Register, START_PC, VM};
 use crate::run::run;
 
 fn main() {

--- a/src/op/mod.rs
+++ b/src/op/mod.rs
@@ -2,6 +2,6 @@ mod op_codes;
 mod trap_codes;
 mod trap_op;
 
-pub use op_codes::OpCode;
+pub use op_codes::{decode_opcode, OpCode};
 pub use trap_codes::TrapCode;
 pub use trap_op::trap;

--- a/src/op/mod.rs
+++ b/src/op/mod.rs
@@ -2,6 +2,6 @@ mod op_codes;
 mod trap_codes;
 mod trap_op;
 
-pub use op_codes::{decode_opcode, OpCode};
+pub use op_codes::{OpCode, decode_opcode};
 pub use trap_codes::TrapCode;
 pub use trap_op::trap;

--- a/src/op/mod.rs
+++ b/src/op/mod.rs
@@ -1,0 +1,7 @@
+mod op_codes;
+mod trap_codes;
+mod trap_op;
+
+pub use op_codes::OpCode;
+pub use trap_codes::TrapCode;
+pub use trap_op::trap;

--- a/src/op/op_codes.rs
+++ b/src/op/op_codes.rs
@@ -1,3 +1,6 @@
+/// LC-3 instruction opcode (upper 4 bits of the instruction word).
+#[repr(u16)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OpCode {
     Br,   /* branch */
     Add,  /* add  */
@@ -15,6 +18,36 @@ pub enum OpCode {
     Res,  /* reserved (unused) */
     Lea,  /* load effective address */
     Trap, /* execute trap */
+}
+
+impl PartialEq<u16> for OpCode {
+    fn eq(&self, other: &u16) -> bool {
+        *self as u16 == *other
+    }
+}
+
+impl From<u16> for OpCode {
+    fn from(value: u16) -> Self {
+        match value {
+            0x0 => OpCode::Br,
+            0x1 => OpCode::Add,
+            0x2 => OpCode::Ld,
+            0x3 => OpCode::St,
+            0x4 => OpCode::Jsr,
+            0x5 => OpCode::And,
+            0x6 => OpCode::Ldr,
+            0x7 => OpCode::Str,
+            0x8 => OpCode::Rti,
+            0x9 => OpCode::Not,
+            0xA => OpCode::Ldi,
+            0xB => OpCode::Sti,
+            0xC => OpCode::Jmp,
+            0xD => OpCode::Res,
+            0xE => OpCode::Lea,
+            0xF => OpCode::Trap,
+            _ => panic!("Invalid opcode value: {}", value),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/op/op_codes.rs
+++ b/src/op/op_codes.rs
@@ -20,6 +20,11 @@ pub enum OpCode {
     Trap, /* execute trap */
 }
 
+/// Decode the opcode bits (bits 15..12) from an instruction word.
+pub fn decode_opcode(instr: u16) -> u16 {
+    instr >> 12
+}
+
 impl PartialEq<u16> for OpCode {
     fn eq(&self, other: &u16) -> bool {
         *self as u16 == *other
@@ -52,6 +57,7 @@ impl From<u16> for OpCode {
 
 #[cfg(test)]
 mod tests {
+    use super::decode_opcode;
     use super::OpCode;
 
     #[test]
@@ -72,5 +78,13 @@ mod tests {
         assert_eq!(OpCode::Res as u16, 0xD);
         assert_eq!(OpCode::Lea as u16, 0xE);
         assert_eq!(OpCode::Trap as u16, 0xF);
+    }
+
+    #[test]
+    fn decode_opcode_extracts_upper_nibble() {
+        for value in 0x0u16..=0xFu16 {
+            let instr = (value << 12) | 0x00A;
+            assert_eq!(decode_opcode(instr), value);
+        }
     }
 }

--- a/src/op/op_codes.rs
+++ b/src/op/op_codes.rs
@@ -57,8 +57,8 @@ impl From<u16> for OpCode {
 
 #[cfg(test)]
 mod tests {
-    use super::decode_opcode;
     use super::OpCode;
+    use super::decode_opcode;
 
     #[test]
     fn opcode_ordinals_match_lc3_order() {

--- a/src/op/trap_codes.rs
+++ b/src/op/trap_codes.rs
@@ -1,0 +1,31 @@
+/// LC-3 TRAP vector codes (lower 8 bits of a TRAP instruction).
+#[repr(u16)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrapCode {
+    Getc = 0x20,  /* get character from keyboard, not echoed onto the terminal */
+    Out = 0x21,   /* output a character */
+    Puts = 0x22,  /* output a word string */
+    In = 0x23,    /* get character from keyboard, echoed onto the terminal */
+    Putsp = 0x24, /* output a byte string */
+    Halt = 0x25,  /* halt the program */
+}
+
+impl PartialEq<u16> for TrapCode {
+    fn eq(&self, other: &u16) -> bool {
+        *self as u16 == *other
+    }
+}
+
+impl From<u16> for TrapCode {
+    fn from(value: u16) -> Self {
+        match value {
+            0x20 => TrapCode::Getc,
+            0x21 => TrapCode::Out,
+            0x22 => TrapCode::Puts,
+            0x23 => TrapCode::In,
+            0x24 => TrapCode::Putsp,
+            0x25 => TrapCode::Halt,
+            _ => panic!("Invalid trap code value: {}", value),
+        }
+    }
+}

--- a/src/op/trap_op.rs
+++ b/src/op/trap_op.rs
@@ -8,16 +8,11 @@ pub fn trap(vm: &mut VM, instr: u16) {
 
     // extract the 8-bit trap vector
     match instr & 0x00FF {
-        x if TrapCode::Getc == x => {
-        }
-        x if TrapCode::Out == x => {
-        }
-        x if TrapCode::Puts == x => {
-        }
-        x if TrapCode::In == x => {
-        }
-        x if TrapCode::Putsp == x => {
-        }
+        x if TrapCode::Getc == x => {}
+        x if TrapCode::Out == x => {}
+        x if TrapCode::Puts == x => {}
+        x if TrapCode::In == x => {}
+        x if TrapCode::Putsp == x => {}
         x if TrapCode::Halt == x => {
             vm.shut_down();
         }

--- a/src/op/trap_op.rs
+++ b/src/op/trap_op.rs
@@ -1,0 +1,33 @@
+use crate::architecture::{Register, VM};
+use crate::op::TrapCode;
+
+/// Execute a TRAP instruction, dispatching by trap vector.
+pub fn trap(vm: &mut VM, instr: u16) {
+    // Save the current PC in R7
+    vm.set_reg(Register::R7.into(), vm.reg(Register::PC.into()));
+
+    // extract the 8-bit trap vector
+    match instr & 0x00FF {
+        x if TrapCode::Getc == x => {
+            return;
+        }
+        x if TrapCode::Out == x => {
+            return;
+        }
+        x if TrapCode::Puts == x => {
+            return;
+        }
+        x if TrapCode::In == x => {
+            return;
+        }
+        x if TrapCode::Putsp == x => {
+            return;
+        }
+        x if TrapCode::Halt == x => {
+            vm.shut_down();
+        }
+        _ => {
+            panic!("Invalid trap code in instruction: {:04X}", instr);
+        }
+    }
+}

--- a/src/op/trap_op.rs
+++ b/src/op/trap_op.rs
@@ -9,19 +9,14 @@ pub fn trap(vm: &mut VM, instr: u16) {
     // extract the 8-bit trap vector
     match instr & 0x00FF {
         x if TrapCode::Getc == x => {
-            return;
         }
         x if TrapCode::Out == x => {
-            return;
         }
         x if TrapCode::Puts == x => {
-            return;
         }
         x if TrapCode::In == x => {
-            return;
         }
         x if TrapCode::Putsp == x => {
-            return;
         }
         x if TrapCode::Halt == x => {
             vm.shut_down();

--- a/src/op_codes/mod.rs
+++ b/src/op_codes/mod.rs
@@ -1,1 +1,0 @@
-pub mod codes;

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,0 +1,9 @@
+use crate::architecture::VM;
+use crate::step::step;
+
+/// Execute VM steps until the machine halts.
+pub fn run(vm: &mut VM) {
+    while vm.is_running() {
+        step(vm);
+    }
+}

--- a/src/step.rs
+++ b/src/step.rs
@@ -14,52 +14,37 @@ pub fn step(vm: &mut VM) {
 
     match op {
         x if OpCode::Add == x => {
-            return;
         }
         x if OpCode::And == x => {
-            return;
         }
         x if OpCode::Not == x => {
-            return;
         }
         x if OpCode::Br == x => {
-            return;
         }
         x if OpCode::Jmp == x => {
-            return;
         }
         x if OpCode::Jsr == x => {
-            return;
         }
         x if OpCode::Ld == x => {
-            return;
         }
         x if OpCode::Ldi == x => {
-            return;
         }
         x if OpCode::Ldr == x => {
-            return;
         }
         x if OpCode::Lea == x => {
-            return;
         }
         x if OpCode::St == x => {
-            return;
         }
         x if OpCode::Sti == x => {
-            return;
         }
         x if OpCode::Str == x => {
-            return;
         }
         x if OpCode::Trap == x => {
             trap(vm, instr);
         }
         x if OpCode::Res == x => {
-            return;
         }
         x if OpCode::Rti == x => {
-            return;
         }
         _ => {}
     }

--- a/src/step.rs
+++ b/src/step.rs
@@ -1,5 +1,5 @@
 use crate::architecture::{Register, VM};
-use crate::op::{decode_opcode, trap, OpCode};
+use crate::op::{OpCode, decode_opcode, trap};
 
 /// Execute a single fetch/decode/dispatch cycle.
 pub fn step(vm: &mut VM) {
@@ -13,39 +13,24 @@ pub fn step(vm: &mut VM) {
     let op: u16 = decode_opcode(instr);
 
     match op {
-        x if OpCode::Add == x => {
-        }
-        x if OpCode::And == x => {
-        }
-        x if OpCode::Not == x => {
-        }
-        x if OpCode::Br == x => {
-        }
-        x if OpCode::Jmp == x => {
-        }
-        x if OpCode::Jsr == x => {
-        }
-        x if OpCode::Ld == x => {
-        }
-        x if OpCode::Ldi == x => {
-        }
-        x if OpCode::Ldr == x => {
-        }
-        x if OpCode::Lea == x => {
-        }
-        x if OpCode::St == x => {
-        }
-        x if OpCode::Sti == x => {
-        }
-        x if OpCode::Str == x => {
-        }
+        x if OpCode::Add == x => {}
+        x if OpCode::And == x => {}
+        x if OpCode::Not == x => {}
+        x if OpCode::Br == x => {}
+        x if OpCode::Jmp == x => {}
+        x if OpCode::Jsr == x => {}
+        x if OpCode::Ld == x => {}
+        x if OpCode::Ldi == x => {}
+        x if OpCode::Ldr == x => {}
+        x if OpCode::Lea == x => {}
+        x if OpCode::St == x => {}
+        x if OpCode::Sti == x => {}
+        x if OpCode::Str == x => {}
         x if OpCode::Trap == x => {
             trap(vm, instr);
         }
-        x if OpCode::Res == x => {
-        }
-        x if OpCode::Rti == x => {
-        }
+        x if OpCode::Res == x => {}
+        x if OpCode::Rti == x => {}
         _ => {}
     }
 }

--- a/src/step.rs
+++ b/src/step.rs
@@ -1,0 +1,66 @@
+use crate::architecture::{Register, VM};
+use crate::op::{trap, OpCode};
+
+/// Execute a single fetch/decode/dispatch cycle.
+pub fn step(vm: &mut VM) {
+    let instr: u16 = vm.read_mem(vm.reg(Register::PC.into()));
+
+    vm.set_reg(
+        Register::PC.into(),
+        vm.reg(Register::PC.into()).wrapping_add(1),
+    );
+
+    let op: u16 = instr >> 12;
+
+    match op {
+        x if OpCode::Add == x => {
+            return;
+        }
+        x if OpCode::And == x => {
+            return;
+        }
+        x if OpCode::Not == x => {
+            return;
+        }
+        x if OpCode::Br == x => {
+            return;
+        }
+        x if OpCode::Jmp == x => {
+            return;
+        }
+        x if OpCode::Jsr == x => {
+            return;
+        }
+        x if OpCode::Ld == x => {
+            return;
+        }
+        x if OpCode::Ldi == x => {
+            return;
+        }
+        x if OpCode::Ldr == x => {
+            return;
+        }
+        x if OpCode::Lea == x => {
+            return;
+        }
+        x if OpCode::St == x => {
+            return;
+        }
+        x if OpCode::Sti == x => {
+            return;
+        }
+        x if OpCode::Str == x => {
+            return;
+        }
+        x if OpCode::Trap == x => {
+            trap(vm, instr);
+        }
+        x if OpCode::Res == x => {
+            return;
+        }
+        x if OpCode::Rti == x => {
+            return;
+        }
+        _ => {}
+    }
+}


### PR DESCRIPTION
Closes #2 
This pull request introduces a significant refactor and foundational improvements to the LC-3 virtual machine implementation. The changes modularize the opcode and trap handling, improve the VM's internal state management, and establish a clear execution cycle. Several enums are enhanced for type safety and ergonomic conversions, and new modules are introduced for stepping and running the VM.

Key changes include:

**Architecture and VM State Improvements:**
- Refactored the `VM` struct to encapsulate registers, memory, and running state, with new methods for register and memory access, and start-up/shutdown logic. The program counter is now initialized to the LC-3 default of `0x3000`. (`src/architecture/vm.rs`, `src/architecture/mod.rs`, `src/architecture/registers.rs`) [[1]](diffhunk://#diff-0dcb1f0a2d0fc9005e0bcd5f323a641cd7a054e832ef15b10625ab8d3a4d22e2R4-R55) [[2]](diffhunk://#diff-22f1b379ead2570f7be14d3ada4b7c3cb7ce8b2c70e5f79111e29f0e949ace5eR8-R9) [[3]](diffhunk://#diff-ddd8d787ddb5518e42c54540f8ab14a8f382f540618019f4eb420b10cc242079R1-R4)
- Added `From` trait implementations for `CondFlag` and `Register` enums, improving type conversions and safety when interacting with registers and condition flags. (`src/architecture/cond_flags.rs`, `src/architecture/registers.rs`) [[1]](diffhunk://#diff-493530739ee212f65936aa5ea7dde55341c94fe581c268177ab5b69664f06ecaR1-R14) [[2]](diffhunk://#diff-ddd8d787ddb5518e42c54540f8ab14a8f382f540618019f4eb420b10cc242079R20-R25)

**Opcode and Trap Handling Modularization:**
- Moved opcode and trap code definitions into a new `op` module, introducing `OpCode` and `TrapCode` enums with conversion and comparison implementations for better decoding and dispatch. (`src/op/mod.rs`, `src/op/op_codes.rs`, `src/op/trap_codes.rs`) [[1]](diffhunk://#diff-2f1a1d383d5978904b93d799e42efc6add583f267bd4fedc97ea946eaf87aa7fR1-R7) [[2]](diffhunk://#diff-e741b05dd307325e3d2326aa84c4a689dc49e7ff32d10f5fe991fdb432ea267bR1-R3) [[3]](diffhunk://#diff-a4a390a11cd8da9d8698cf39a0ad27a9f4aa8c2f78336c42f01c871a0779e5acR1-R31)
- Implemented the `trap` function to handle TRAP instructions, including the HALT operation which now shuts down the VM. (`src/op/trap_op.rs`)

**Execution Flow and Testing:**
- Added `step` and `run` modules to encapsulate the fetch/decode/execute cycle and continuous execution loop, respectively. The `step` function now dispatches instructions by opcode and integrates with the new trap handling. Tests verify correct PC increment and HALT behavior. (`src/step.rs`, `src/run.rs`) [[1]](diffhunk://#diff-3c5d1bdba59e92edff0cc8e4744a0b991cde655eaab13838c618de36e520c67eR1-R67) [[2]](diffhunk://#diff-1d06da761111802c793c6e5ca704bfa0d6336d0becf87fddff02d81548a838abR1-R9)
- Updated `main.rs` to use the new VM interface and run loop, initializing condition flags and program counter appropriately. (`src/main.rs`)

**Helper and Test Updates:**
- Updated helper functions and tests to use new type conversions for registers and condition flags, improving code clarity and correctness. (`src/helper_funcs/update_flags.rs`) [[1]](diffhunk://#diff-cbce97b0c1161e12824c751358f50ec63bd7fd0564faa1316bfdcac1cdbc0b0eL19-R29) [[2]](diffhunk://#diff-cbce97b0c1161e12824c751358f50ec63bd7fd0564faa1316bfdcac1cdbc0b0eL44-R44) [[3]](diffhunk://#diff-cbce97b0c1161e12824c751358f50ec63bd7fd0564faa1316bfdcac1cdbc0b0eL54-R54) [[4]](diffhunk://#diff-cbce97b0c1161e12824c751358f50ec63bd7fd0564faa1316bfdcac1cdbc0b0eL64-R64)
- Improved documentation and added doc comments to clarify the purpose of enums, functions, and modules throughout the codebase. (`src/architecture/cond_flags.rs`, `src/architecture/vm.rs`, `src/helper_funcs/read_u16_be.rs`, `src/op/op_codes.rs`, `src/op/trap_codes.rs`, `src/op/trap_op.rs`, `src/run.rs`, `src/step.rs`) [[1]](diffhunk://#diff-493530739ee212f65936aa5ea7dde55341c94fe581c268177ab5b69664f06ecaR1-R14) [[2]](diffhunk://#diff-0dcb1f0a2d0fc9005e0bcd5f323a641cd7a054e832ef15b10625ab8d3a4d22e2R4-R55) [[3]](diffhunk://#diff-be2e7e1e9fefafa815c5781dfede295d31521ed535e781a01516d2a30fe5b2f0R3) [[4]](diffhunk://#diff-e741b05dd307325e3d2326aa84c4a689dc49e7ff32d10f5fe991fdb432ea267bR1-R3) [[5]](diffhunk://#diff-a4a390a11cd8da9d8698cf39a0ad27a9f4aa8c2f78336c42f01c871a0779e5acR1-R31) [[6]](diffhunk://#diff-e60cbe79b21111cd1a6f7a5b342549c17e298beb3c302991dffce7666fe30112R1-R23) [[7]](diffhunk://#diff-1d06da761111802c793c6e5ca704bfa0d6336d0becf87fddff02d81548a838abR1-R9) [[8]](diffhunk://#diff-3c5d1bdba59e92edff0cc8e4744a0b991cde655eaab13838c618de36e520c67eR1-R67)

These changes lay the groundwork for a more maintainable and extensible LC-3 VM, with clear separation of concerns and improved type safety.